### PR TITLE
fix: add publishers as URIRefs

### DIFF
--- a/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
@@ -326,12 +326,16 @@ private fun String?.getIfNotNullOrEmpty(): String? =
 
 fun Resource.addPublisher(publisher: Publisher?): Resource {
     publisher?.let {
-        addProperty(DCTerms.publisher,
-            model.safeCreateResource(it.uri.getIfNotNullOrEmpty() ?: it.id.getIfNotNullOrEmpty())
-                .addProperty(RDF.type, FOAF.Agent)
-                .addPublisherName(it)
-                .safeAddLiteralByLang(SKOS.prefLabel, it.prefLabel)
-                .safeAddStringLiteral(DCTerms.identifier, it.id))
+        if (it.uri != null) addProperty(DCTerms.publisher, model.safeCreateResource(it.uri))
+        else {
+            addProperty(
+                DCTerms.publisher,
+                model.createResource()
+                    .addProperty(RDF.type, FOAF.Agent)
+                    .addPublisherName(it)
+                    .safeAddStringLiteral(DCTerms.identifier, it.id)
+            )
+        }
     }
     return this
 }

--- a/src/test/resources/catalog_2.ttl
+++ b/src/test/resources/catalog_2.ttl
@@ -59,11 +59,6 @@
                 "ENG" ;
         skos:prefLabel  "Engelsk"@nb .
 
-<http://data.brreg.no/enhetsregisteret/enhet/987654321>
-        a               foaf:Agent ;
-        dct:identifier  "987654321" ;
-        foaf:name       "TESTETATEN" .
-
 <http://uri-1>  a   rdfs:Resource ;
         rdfs:label  "label-1-en"@en , "label-1-nb"@nb .
 


### PR DESCRIPTION
Har et problem med at utgivernavn ikke endrer seg i portal etter at det har blitt oppdatert i organization-catalogue. Så endrer litt i måten publisher blir serialisert.

URI er tilgjengelig:
```
dct: publisher    <http://data.brreg.no/enhetsregisteret/enhet/987654321>
```

URI er ikke tilgjengelig:
```
dct: publisher    [
                    a               foaf:Agent ;
                    dct:identifier  "987654321" ;
                    foaf:name       "TESTETATEN"
                  ]
```