### PR TITLE
feat: flexible-precision temporal dates

### DIFF
--- a/src/main/kotlin/no/fdk/dataset_catalog/model/DatasetDBO.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/model/DatasetDBO.kt
@@ -189,12 +189,8 @@ data class DistributionDBO(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PeriodOfTimeDBO(
-    @param:JsonSerialize(using = LocalDateSerializer::class)
-    @param:JsonDeserialize(using = LocalDateDeserializer::class)
-    val startDate: LocalDate? = null,
-    @param:JsonSerialize(using = LocalDateSerializer::class)
-    @param:JsonDeserialize(using = LocalDateDeserializer::class)
-    val endDate: LocalDate? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
@@ -73,6 +73,17 @@ fun Resource.safeAddDateTimeLiteral(property: Property, dateTime: LocalDate?): R
         safeAddLiteral(property, model.createTypedLiteral(dateTime.toString(), XSDDatatype.XSDdate))
     } else this
 
+fun Resource.safeAddFlexibleDateLiteral(property: Property, value: String?): Resource {
+    if (value.isNullOrEmpty()) return this
+    val xsdType = when (value.length) {
+        4 -> XSDDatatype.XSDgYear
+        7 -> XSDDatatype.XSDgYearMonth
+        10 -> XSDDatatype.XSDdate
+        else -> return this
+    }
+    return safeAddLiteral(property, model.createTypedLiteral(value, xsdType))
+}
+
 fun Resource.safeAddLinkedProperty(property: Property, value: String?): Resource =
     if (value.isNullOrEmpty()) this
     else addProperty(property, model.createResource(value))
@@ -232,13 +243,13 @@ private fun Resource.addRule(rule: UriWithLabel, ruleType: Resource): Resource {
 
 fun Resource.addTemporal(temporal: List<PeriodOfTimeDBO>?): Resource {
     temporal?.forEach {
-        if (it.startDate != null || it.endDate != null) {
+        if (!it.startDate.isNullOrEmpty() || !it.endDate.isNullOrEmpty()) {
             addProperty(
                 DCTerms.temporal,
                 model.safeCreateResource()
                     .addProperty(RDF.type, DCTerms.PeriodOfTime)
-                    .safeAddDateTimeLiteral(Schema.startDate, it.startDate)
-                    .safeAddDateTimeLiteral(Schema.endDate, it.endDate)
+                    .safeAddFlexibleDateLiteral(Schema.startDate, it.startDate)
+                    .safeAddFlexibleDateLiteral(Schema.endDate, it.endDate)
             )
         }
     }

--- a/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/rdf/RDFUtils.kt
@@ -81,6 +81,7 @@ fun Resource.safeAddFlexibleDateLiteral(property: Property, value: String?): Res
         10 -> XSDDatatype.XSDdate
         else -> return this
     }
+    if (!xsdType.isValid(value)) return this
     return safeAddLiteral(property, model.createTypedLiteral(value, xsdType))
 }
 

--- a/src/main/kotlin/no/fdk/dataset_catalog/service/DatasetService.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/service/DatasetService.kt
@@ -9,6 +9,7 @@ import no.fdk.dataset_catalog.configuration.ApplicationProperties
 import no.fdk.dataset_catalog.extensions.addCreateValues
 import no.fdk.dataset_catalog.model.*
 import no.fdk.dataset_catalog.repository.DatasetRepository
+import no.fdk.dataset_catalog.validation.TemporalValidator
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
@@ -66,6 +67,7 @@ class DatasetService(
         )
 
         newDataset.addCreateValues(values)
+            .also { TemporalValidator.validate(it) }
             .allAffectedSeriesDatasets(null)
             .let { persistAndHarvestDatasets(it, catalogId) }
 
@@ -191,7 +193,7 @@ class DatasetService(
 
     private fun DatasetDBO.update(operations: List<JsonPatchOperation>): DatasetDBO {
         validateOperations(operations)
-        return try {
+        val patched = try {
             patchDatasetDBO(this, operations)
         } catch (ex: Exception) {
             logger.error("PATCH failed for $id", ex)
@@ -203,6 +205,8 @@ class DatasetService(
                 else -> throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.message)
             }
         }
+        TemporalValidator.validate(patched)
+        return patched
     }
 
     private fun patchDatasetDBO(dataset: DatasetDBO, operations: List<JsonPatchOperation>): DatasetDBO {

--- a/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
@@ -13,8 +13,6 @@ import java.time.format.ResolverStyle
 
 object TemporalValidator {
 
-    private val FORMAT_REGEX = Regex("""^\d{4}$|^\d{4}-\d{2}$|^\d{4}-\d{2}-\d{2}$""")
-
     private val YEAR_FMT: DateTimeFormatter =
         DateTimeFormatter.ofPattern("uuuu").withResolverStyle(ResolverStyle.STRICT)
     private val YEAR_MONTH_FMT: DateTimeFormatter =
@@ -42,19 +40,17 @@ object TemporalValidator {
     }
 
     private fun validateValue(value: String, path: String) {
-        if (!FORMAT_REGEX.matches(value)) {
-            throw badRequest(
-                "$path: '$value' is not in format yyyy, yyyy-MM, or yyyy-MM-dd"
-            )
-        }
         try {
             when (value.length) {
                 4 -> Year.parse(value, YEAR_FMT)
                 7 -> YearMonth.parse(value, YEAR_MONTH_FMT)
-                else -> LocalDate.parse(value, DATE_FMT)
+                10 -> LocalDate.parse(value, DATE_FMT)
+                else -> throw badRequest(
+                    "$path: '$value' must be yyyy, yyyy-MM, or yyyy-MM-dd"
+                )
             }
         } catch (ex: DateTimeParseException) {
-            throw badRequest("$path: '$value' is not a valid calendar date")
+            throw badRequest("$path: '$value' is not a valid date")
         }
     }
 

--- a/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
@@ -1,0 +1,77 @@
+package no.fdk.dataset_catalog.validation
+
+import no.fdk.dataset_catalog.model.DatasetDBO
+import no.fdk.dataset_catalog.model.PeriodOfTimeDBO
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDate
+import java.time.Year
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.ResolverStyle
+
+object TemporalValidator {
+
+    private val FORMAT_REGEX = Regex("""^\d{4}$|^\d{4}-\d{2}$|^\d{4}-\d{2}-\d{2}$""")
+
+    private val YEAR_FMT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("uuuu").withResolverStyle(ResolverStyle.STRICT)
+    private val YEAR_MONTH_FMT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("uuuu-MM").withResolverStyle(ResolverStyle.STRICT)
+    private val DATE_FMT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT)
+
+    fun validate(dataset: DatasetDBO) {
+        dataset.temporal?.forEachIndexed { index, period -> validatePeriod(period, index) }
+    }
+
+    private fun validatePeriod(period: PeriodOfTimeDBO, index: Int) {
+        period.startDate?.let { validateValue(it, "temporal[$index].startDate") }
+        period.endDate?.let { validateValue(it, "temporal[$index].endDate") }
+
+        val start = period.startDate
+        val end = period.endDate
+        if (start != null && end != null) {
+            if (startBound(start).isAfter(endBound(end))) {
+                throw badRequest(
+                    "temporal[$index]: startDate ($start) must not be after endDate ($end)"
+                )
+            }
+        }
+    }
+
+    private fun validateValue(value: String, path: String) {
+        if (!FORMAT_REGEX.matches(value)) {
+            throw badRequest(
+                "$path: '$value' is not in format yyyy, yyyy-MM, or yyyy-MM-dd"
+            )
+        }
+        try {
+            when (value.length) {
+                4 -> Year.parse(value, YEAR_FMT)
+                7 -> YearMonth.parse(value, YEAR_MONTH_FMT)
+                10 -> LocalDate.parse(value, DATE_FMT)
+            }
+        } catch (ex: DateTimeParseException) {
+            throw badRequest("$path: '$value' is not a valid calendar date")
+        }
+    }
+
+    private fun startBound(value: String): LocalDate = when (value.length) {
+        4 -> LocalDate.of(value.toInt(), 1, 1)
+        7 -> YearMonth.parse(value, YEAR_MONTH_FMT).atDay(1)
+        10 -> LocalDate.parse(value, DATE_FMT)
+        else -> error("unreachable: value validated before bound computation")
+    }
+
+    private fun endBound(value: String): LocalDate = when (value.length) {
+        4 -> LocalDate.of(value.toInt(), 12, 31)
+        7 -> YearMonth.parse(value, YEAR_MONTH_FMT).atEndOfMonth()
+        10 -> LocalDate.parse(value, DATE_FMT)
+        else -> error("unreachable: value validated before bound computation")
+    }
+
+    private fun badRequest(message: String): ResponseStatusException =
+        ResponseStatusException(HttpStatus.BAD_REQUEST, message)
+}

--- a/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
+++ b/src/main/kotlin/no/fdk/dataset_catalog/validation/TemporalValidator.kt
@@ -51,7 +51,7 @@ object TemporalValidator {
             when (value.length) {
                 4 -> Year.parse(value, YEAR_FMT)
                 7 -> YearMonth.parse(value, YEAR_MONTH_FMT)
-                10 -> LocalDate.parse(value, DATE_FMT)
+                else -> LocalDate.parse(value, DATE_FMT)
             }
         } catch (ex: DateTimeParseException) {
             throw badRequest("$path: '$value' is not a valid calendar date")
@@ -61,15 +61,13 @@ object TemporalValidator {
     private fun startBound(value: String): LocalDate = when (value.length) {
         4 -> LocalDate.of(value.toInt(), 1, 1)
         7 -> YearMonth.parse(value, YEAR_MONTH_FMT).atDay(1)
-        10 -> LocalDate.parse(value, DATE_FMT)
-        else -> error("unreachable: value validated before bound computation")
+        else -> LocalDate.parse(value, DATE_FMT)
     }
 
     private fun endBound(value: String): LocalDate = when (value.length) {
         4 -> LocalDate.of(value.toInt(), 12, 31)
         7 -> YearMonth.parse(value, YEAR_MONTH_FMT).atEndOfMonth()
-        10 -> LocalDate.parse(value, DATE_FMT)
-        else -> error("unreachable: value validated before bound computation")
+        else -> LocalDate.parse(value, DATE_FMT)
     }
 
     private fun badRequest(message: String): ResponseStatusException =

--- a/src/main/resources/specification/specification.yaml
+++ b/src/main/resources/specification/specification.yaml
@@ -830,12 +830,12 @@ components:
           description: Period name
         startDate:
           type: string
-          format: date
-          description: Date of period start
+          pattern: "^\\d{4}$|^\\d{4}-\\d{2}$|^\\d{4}-\\d{2}-\\d{2}$"
+          description: "Start of period as ISO-8601 partial date. Accepts year (yyyy), year-month (yyyy-MM), or full date (yyyy-MM-dd)."
         endDate:
           type: string
-          format: date
-          description: Date of period end
+          pattern: "^\\d{4}$|^\\d{4}-\\d{2}$|^\\d{4}-\\d{2}-\\d{2}$"
+          description: "End of period as ISO-8601 partial date. Accepts year (yyyy), year-month (yyyy-MM), or full date (yyyy-MM-dd)."
     SkosConcept:
       type: object
       description: Skos Concept

--- a/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
@@ -102,6 +102,14 @@ class RDFDatasetUtilsTest {
         assertFalse { resource.hasProperty(DCTerms.temporal) }
     }
 
+    @Test
+    fun flexibleDateLiteralIgnoresMalformedLength() {
+        val model = ModelFactory.createDefaultModel()
+        val resource = model.createResource("http://my-dataset-malformed")
+        resource.safeAddFlexibleDateLiteral(Schema.startDate, "2024-06-1")
+        assertFalse { resource.hasProperty(Schema.startDate) }
+    }
+
     private fun temporalDatatype(period: PeriodOfTimeDBO, property: org.apache.jena.rdf.model.Property): String {
         val model = ModelFactory.createDefaultModel()
         val resource = model.createResource("http://my-dataset-temporal")

--- a/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
@@ -110,6 +110,16 @@ class RDFDatasetUtilsTest {
         assertFalse { resource.hasProperty(Schema.startDate) }
     }
 
+    @Test
+    fun flexibleDateLiteralIgnoresLexicallyInvalidValue() {
+        val model = ModelFactory.createDefaultModel()
+        val resource = model.createResource("http://my-dataset-lexical")
+        resource.safeAddFlexibleDateLiteral(Schema.startDate, "abcd")
+        resource.safeAddFlexibleDateLiteral(Schema.endDate, "2024-13-01")
+        assertFalse { resource.hasProperty(Schema.startDate) }
+        assertFalse { resource.hasProperty(Schema.endDate) }
+    }
+
     private fun temporalDatatype(period: PeriodOfTimeDBO, property: org.apache.jena.rdf.model.Property): String {
         val model = ModelFactory.createDefaultModel()
         val resource = model.createResource("http://my-dataset-temporal")

--- a/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/rdf/RDFDatasetUtilsTest.kt
@@ -2,13 +2,19 @@ package no.fdk.dataset_catalog.rdf
 
 import no.fdk.dataset_catalog.model.DistributionDBO
 import no.fdk.dataset_catalog.model.LocalizedStrings
+import no.fdk.dataset_catalog.model.PeriodOfTimeDBO
 import no.fdk.dataset_catalog.model.UriWithLabel
+import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.vocabulary.DCTerms
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
+@Tag("unit")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RDFDatasetUtilsTest {
     @Test
@@ -57,6 +63,51 @@ class RDFDatasetUtilsTest {
         resource.addDatasetDistribution(ADMS.sample, listOf(DistributionDBO(accessURL = listOf("http://access-url"))))
 
         assertTrue { resource.hasProperty(ADMS.sample) }
+    }
+
+    @Test
+    fun yearOnlyTemporalEmitsXsdGYear() {
+        val datatype = temporalDatatype(PeriodOfTimeDBO(startDate = "2024"), Schema.startDate)
+        assertEquals(XSDDatatype.XSDgYear.uri, datatype)
+    }
+
+    @Test
+    fun yearMonthTemporalEmitsXsdGYearMonth() {
+        val datatype = temporalDatatype(PeriodOfTimeDBO(startDate = "2024-06"), Schema.startDate)
+        assertEquals(XSDDatatype.XSDgYearMonth.uri, datatype)
+    }
+
+    @Test
+    fun fullDateTemporalEmitsXsdDate() {
+        val datatype = temporalDatatype(PeriodOfTimeDBO(startDate = "2024-06-15"), Schema.startDate)
+        assertEquals(XSDDatatype.XSDdate.uri, datatype)
+    }
+
+    @Test
+    fun mixedPrecisionStartAndEndEmitDistinctTypes() {
+        val model = ModelFactory.createDefaultModel()
+        val resource = model.createResource("http://my-dataset-mixed")
+        resource.addTemporal(listOf(PeriodOfTimeDBO(startDate = "2024", endDate = "2024-06")))
+
+        val period = resource.getProperty(DCTerms.temporal).`object`.asResource()
+        assertEquals(XSDDatatype.XSDgYear.uri, period.getProperty(Schema.startDate).literal.datatypeURI)
+        assertEquals(XSDDatatype.XSDgYearMonth.uri, period.getProperty(Schema.endDate).literal.datatypeURI)
+    }
+
+    @Test
+    fun emptyTemporalPeriodNotEmitted() {
+        val model = ModelFactory.createDefaultModel()
+        val resource = model.createResource("http://my-dataset-empty")
+        resource.addTemporal(listOf(PeriodOfTimeDBO(startDate = "", endDate = null)))
+        assertFalse { resource.hasProperty(DCTerms.temporal) }
+    }
+
+    private fun temporalDatatype(period: PeriodOfTimeDBO, property: org.apache.jena.rdf.model.Property): String {
+        val model = ModelFactory.createDefaultModel()
+        val resource = model.createResource("http://my-dataset-temporal")
+        resource.addTemporal(listOf(period))
+        val periodResource = resource.getProperty(DCTerms.temporal).`object`.asResource()
+        return periodResource.getProperty(property).literal.datatypeURI
     }
 
 }

--- a/src/test/kotlin/no/fdk/dataset_catalog/service/DatasetServiceTest.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/service/DatasetServiceTest.kt
@@ -8,7 +8,6 @@ import no.fdk.dataset_catalog.utils.TEST_DATASET_1
 import org.junit.jupiter.api.*
 import org.mockito.kotlin.*
 import org.springframework.web.server.ResponseStatusException
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import kotlin.test.assertEquals
@@ -39,6 +38,38 @@ class DatasetServiceTest {
                 val actual = firstValue.first()
                 assertEquals(actual.copy(specializedType = ds.specializedType), actual)
             }
+        }
+
+        @Test
+        fun `persists year-only temporal verbatim`() {
+            val ds = DatasetToCreate(
+                temporal = listOf(PeriodOfTimeDBO(startDate = "2024", endDate = "2024-06"))
+            )
+            datasetService.createDataset("catId", ds)
+            argumentCaptor<List<DatasetDBO>>().apply {
+                verify(datasetRepository, times(1)).saveAll(capture())
+                assertEquals("2024", firstValue.first().temporal?.get(0)?.startDate)
+                assertEquals("2024-06", firstValue.first().temporal?.get(0)?.endDate)
+            }
+        }
+
+        @Test
+        fun `rejects invalid calendar date on create`() {
+            val ds = DatasetToCreate(
+                temporal = listOf(PeriodOfTimeDBO(startDate = "2023-02-29"))
+            )
+            val ex = assertThrows<ResponseStatusException> { datasetService.createDataset("catId", ds) }
+            assertEquals(org.springframework.http.HttpStatus.BAD_REQUEST, ex.statusCode)
+            verify(datasetRepository, times(0)).saveAll(any<List<DatasetDBO>>())
+        }
+
+        @Test
+        fun `rejects start after end on create`() {
+            val ds = DatasetToCreate(
+                temporal = listOf(PeriodOfTimeDBO(startDate = "2024-06-15", endDate = "2024-06-14"))
+            )
+            val ex = assertThrows<ResponseStatusException> { datasetService.createDataset("catId", ds) }
+            assertEquals(org.springframework.http.HttpStatus.BAD_REQUEST, ex.statusCode)
         }
     }
 
@@ -132,23 +163,13 @@ class DatasetServiceTest {
                 "catId",
                 uri = "uri",
                 lastModified = LocalDateTime.now(),
-                temporal = listOf(
-                    PeriodOfTimeDBO(
-                        LocalDate.of(2020, 11, 11),
-                        LocalDate.of(2021, 4, 4)
-                    )
-                )
+                temporal = listOf(PeriodOfTimeDBO("2020-11-11", "2021-04-04"))
             )
             val expected = DatasetDBO(
                 "dsId",
                 "catId", uri = "uri",
                 lastModified = LocalDateTime.now(),
-                temporal = listOf(
-                    PeriodOfTimeDBO(
-                        LocalDate.of(2020, 10, 10),
-                        LocalDate.of(2021, 4, 4)
-                    )
-                )
+                temporal = listOf(PeriodOfTimeDBO("2020-10-10", "2021-04-04"))
             )
             whenever(datasetRepository.findById("dsId")).thenReturn(Optional.of(ds))
             datasetService.updateDatasetDBO(
@@ -246,6 +267,42 @@ class DatasetServiceTest {
             }
             argumentCaptor<List<DatasetDBO>>().apply {
                 verify(datasetRepository, times(0)).saveAll(capture())
+            }
+        }
+
+        @Test
+        fun `patch with invalid temporal value returns BAD_REQUEST`() {
+            val ds = DatasetDBO(
+                "dsId", "catId", uri = "uri", lastModified = LocalDateTime.now(),
+                temporal = listOf(PeriodOfTimeDBO("2024-06-01", "2024-06-30"))
+            )
+            whenever(datasetRepository.findById("dsId")).thenReturn(Optional.of(ds))
+            val ex = assertThrows<ResponseStatusException> {
+                datasetService.updateDatasetDBO(
+                    "catId",
+                    "dsId",
+                    listOf(JsonPatchOperation(OpEnum.REPLACE, "/temporal/0/startDate", "not-a-date"))
+                )
+            }
+            assertEquals(org.springframework.http.HttpStatus.BAD_REQUEST, ex.statusCode)
+            verify(datasetRepository, times(0)).saveAll(any<List<DatasetDBO>>())
+        }
+
+        @Test
+        fun `patch with year-only temporal value accepted`() {
+            val ds = DatasetDBO(
+                "dsId", "catId", uri = "uri", lastModified = LocalDateTime.now(),
+                temporal = listOf(PeriodOfTimeDBO("2024-06-01", "2024-06-30"))
+            )
+            whenever(datasetRepository.findById("dsId")).thenReturn(Optional.of(ds))
+            datasetService.updateDatasetDBO(
+                "catId",
+                "dsId",
+                listOf(JsonPatchOperation(OpEnum.REPLACE, "/temporal/0/startDate", "2024"))
+            )
+            argumentCaptor<List<DatasetDBO>>().apply {
+                verify(datasetRepository, times(1)).saveAll(capture())
+                assertEquals("2024", firstValue.first().temporal?.get(0)?.startDate)
             }
         }
     }

--- a/src/test/kotlin/no/fdk/dataset_catalog/utils/TestDataset_0.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/utils/TestDataset_0.kt
@@ -38,8 +38,8 @@ val SAMPLE_EX = DistributionDBO(
 )
 
 val PERIODOFTIME_EX = PeriodOfTimeDBO(
-    startDate = LocalDate.now(),
-    endDate = LocalDate.now().plusYears(1)
+    startDate = LocalDate.now().toString(),
+    endDate = LocalDate.now().plusYears(1).toString()
 )
 
 val QUALITYANNOTATION_EX = QualityAnnotationDBO(

--- a/src/test/kotlin/no/fdk/dataset_catalog/utils/TestDataset_1.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/utils/TestDataset_1.kt
@@ -85,7 +85,7 @@ val TEST_DATASET_1 = DatasetDBO(
     informationModelsFromFDK = listOf(
         "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/catalog-of-models-for-specifications.ttl#dqv-ap-no-model",
         "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/SkatvalModellkatalog.ttl#AdresseModell"),
-    temporal = listOf(PeriodOfTimeDBO(startDate = LocalDate.of(2017,1,1),endDate = LocalDate.of(2017,12,31)), PeriodOfTimeDBO(endDate=LocalDate.of(2018,10,20))),
+    temporal = listOf(PeriodOfTimeDBO(startDate = "2017-01-01", endDate = "2017-12-31"), PeriodOfTimeDBO(endDate = "2018-10-20")),
     concepts = setOf(CONCEPT),
     frequency="http://publications.europa.eu/resource/authority/frequency/ANNUAL",
     issued=LocalDate.of(2012, 1, 1),

--- a/src/test/kotlin/no/fdk/dataset_catalog/validation/TemporalValidatorTest.kt
+++ b/src/test/kotlin/no/fdk/dataset_catalog/validation/TemporalValidatorTest.kt
@@ -1,0 +1,158 @@
+package no.fdk.dataset_catalog.validation
+
+import no.fdk.dataset_catalog.model.DatasetDBO
+import no.fdk.dataset_catalog.model.PeriodOfTimeDBO
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@Tag("unit")
+class TemporalValidatorTest {
+
+    private fun dataset(vararg periods: PeriodOfTimeDBO) = DatasetDBO(
+        id = "id",
+        catalogId = "cat",
+        lastModified = LocalDateTime.now(),
+        uri = "uri",
+        temporal = periods.toList()
+    )
+
+    private fun assertRejected(period: PeriodOfTimeDBO) {
+        val ex = assertThrows(ResponseStatusException::class.java) {
+            TemporalValidator.validate(dataset(period))
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `null temporal accepted`() {
+        TemporalValidator.validate(
+            DatasetDBO(id = "id", catalogId = "cat", lastModified = LocalDateTime.now(), uri = "uri", temporal = null)
+        )
+    }
+
+    @Test
+    fun `empty temporal list accepted`() {
+        TemporalValidator.validate(dataset())
+    }
+
+    @Test
+    fun `period with both bounds null accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO()))
+    }
+
+    @Test
+    fun `valid year-only accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024", endDate = "2024")))
+    }
+
+    @Test
+    fun `valid year-month accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06", endDate = "2024-12")))
+    }
+
+    @Test
+    fun `valid full date accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06-15", endDate = "2024-12-31")))
+    }
+
+    @Test
+    fun `mixed precision accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024", endDate = "2024-06-15")))
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06", endDate = "2024-06-15")))
+    }
+
+    @Test
+    fun `only startDate accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024")))
+    }
+
+    @Test
+    fun `only endDate accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(endDate = "2024")))
+    }
+
+    @Test
+    fun `empty string rejected`() {
+        assertRejected(PeriodOfTimeDBO(startDate = ""))
+        assertRejected(PeriodOfTimeDBO(endDate = ""))
+    }
+
+    @Test
+    fun `whitespace rejected`() {
+        assertRejected(PeriodOfTimeDBO(startDate = " 2024 "))
+        assertRejected(PeriodOfTimeDBO(startDate = "2024 "))
+    }
+
+    @Test
+    fun `malformed strings rejected`() {
+        listOf("24-01", "2024/01", "2024-1-1", "abcd", "2024-", "2024-06-", "20240615").forEach {
+            assertRejected(PeriodOfTimeDBO(startDate = it))
+        }
+    }
+
+    @Test
+    fun `invalid calendar date rejected`() {
+        listOf("2023-02-29", "2024-02-30", "2024-13-01", "2024-00-15", "2024-04-31").forEach {
+            assertRejected(PeriodOfTimeDBO(startDate = it))
+        }
+    }
+
+    @Test
+    fun `leap year February 29 accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-02-29")))
+    }
+
+    @Test
+    fun `end before start on full date rejected`() {
+        assertRejected(PeriodOfTimeDBO(startDate = "2024-06-15", endDate = "2024-06-14"))
+    }
+
+    @Test
+    fun `end before start on year-month rejected`() {
+        assertRejected(PeriodOfTimeDBO(startDate = "2024-06", endDate = "2024-05"))
+    }
+
+    @Test
+    fun `same date accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06-15", endDate = "2024-06-15")))
+    }
+
+    @Test
+    fun `year-month start within year end accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06", endDate = "2024")))
+    }
+
+    @Test
+    fun `year start with year-month end accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024", endDate = "2024-06")))
+    }
+
+    @Test
+    fun `date within month end accepted`() {
+        TemporalValidator.validate(dataset(PeriodOfTimeDBO(startDate = "2024-06-30", endDate = "2024-06")))
+    }
+
+    @Test
+    fun `date after month end rejected`() {
+        assertRejected(PeriodOfTimeDBO(startDate = "2024-07-01", endDate = "2024-06"))
+    }
+
+    @Test
+    fun `error message identifies period index`() {
+        val ex = assertThrows(ResponseStatusException::class.java) {
+            TemporalValidator.validate(
+                dataset(
+                    PeriodOfTimeDBO(startDate = "2024"),
+                    PeriodOfTimeDBO(startDate = "bogus")
+                )
+            )
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+        assert(ex.reason!!.contains("temporal[1].startDate"))
+    }
+}


### PR DESCRIPTION
# Summary fixes #1248

- Change `PeriodOfTimeDBO.startDate`/`endDate` from `LocalDate` to `String` to preserve year/year-month precision on round-trip
- Add `TemporalValidator` with regex + strict calendar parse and mixed-precision order check, returning 400 on invalid input
- Wire validator into `DatasetService` for both POST and PATCH paths
- Update RDF serialization to emit `xsd:gYear`, `xsd:gYearMonth`, or `xsd:date` based on precision
- Update OpenAPI spec: replace `format: date` with pattern on temporal `startDate`/`endDate`
- Add 35+ new tests covering validation, RDF precision, and service integration